### PR TITLE
remove reference to dce async chunk from _js_dist attribute

### DIFF
--- a/dash_chart_editor/__init__.py
+++ b/dash_chart_editor/__init__.py
@@ -29,7 +29,7 @@ _current_path = _os.path.dirname(_os.path.abspath(__file__))
 
 _this_module = _sys.modules[__name__]
 
-async_resources = ["DashChartEditor",]
+async_resources = []
 
 _js_dist = []
 


### PR DESCRIPTION
resolves https://github.com/BSd3v/dash-chart-editor/issues/11 by removing the references to the async chunk so dash doesn't try to load one when `eager_loading=True`

The example in https://github.com/BSd3v/dash-chart-editor/issues/11#issue-1649689190 runs if I add `dce._js_dist[:-2] = []` before initializing the app